### PR TITLE
Fix uninitialized activation_id in layer constructors

### DIFF
--- a/layers/convolution.cpp
+++ b/layers/convolution.cpp
@@ -19,6 +19,8 @@ Convolution::Convolution(std::vector<size_t>& p_input_size, size_t p_num_filters
 
     output_size = {out_h, out_w, num_filters};
 
+    activation_id = p_activation_id;
+
     size_t amt = filter_size * filter_size * input_size[2];
     if (activation_id != ActivationID::RELU) amt += filter_size * filter_size * num_filters;
 
@@ -34,8 +36,6 @@ Convolution::Convolution(std::vector<size_t>& p_input_size, size_t p_num_filters
 
     v_weights = xt::zeros_like(weights);
     v_biases = xt::zeros_like(biases);
-
-    activation_id = p_activation_id;
 
     activation_function = get_activation_function(activation_id);
     activation_derivative = get_activation_derivative(activation_id);

--- a/layers/dense.cpp
+++ b/layers/dense.cpp
@@ -14,6 +14,8 @@ Dense::Dense(const std::vector<std::size_t>& p_input_size, size_t p_num_neurons,
     output_size = p_input_size;
     output_size[output_size.size() - 1] = out_neurons;
 
+    activation_id = p_activation_id;
+
     float stddev = std::sqrt(2.0f / static_cast<float>(inp_neurons + out_neurons));
     if (activation_id == ActivationID::RELU) stddev = std::sqrt(2.0f / static_cast<float>(inp_neurons));
 
@@ -28,8 +30,6 @@ Dense::Dense(const std::vector<std::size_t>& p_input_size, size_t p_num_neurons,
 
     v_weights = xt::zeros_like(weights);
     v_biases = xt::zeros_like(biases);
-
-    activation_id = p_activation_id;
 
     activation_function = get_activation_function(activation_id);
     activation_derivative = get_activation_derivative(activation_id);


### PR DESCRIPTION
## Summary
- assign activation ID before it is used in `Dense` and `Convolution`

## Testing
- `cmake -S . -B build` *(fails: could not find OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_68405e255f448327a7eb40d8b6a456b1