### PR TITLE
Fix beta2 save order in training info

### DIFF
--- a/neural_network.cpp
+++ b/neural_network.cpp
@@ -367,7 +367,7 @@ void NeuralNetwork::save(std::string& file_prefix) {
 
     info_file << train_info.lr << std::endl;
     info_file << train_info.beta1 << std::endl;
-    info_file << train_info.beta1 << std::endl;
+    info_file << train_info.beta2 << std::endl;
     info_file << train_info.weight_decay << std::endl;
 
     info_file.close();


### PR DESCRIPTION
## Summary
- correct `beta2` output in `NeuralNetwork::save`
- keep loading logic aligned with save order

## Testing
- `cmake ..` *(fails: Could not find OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_6840606d7d08832795afe7f0de426825