### PR TITLE
Fix load/save reliability

### DIFF
--- a/layers/attention.cpp
+++ b/layers/attention.cpp
@@ -183,44 +183,36 @@ void Attention::update_adamw(float lr, float beta1, float beta2, float weight_de
 
 void Attention::save_weights(std::vector<float>& all) {
     save_2d(all, weights_q);
-    save_2d(all, grad_weights_q);
     save_2d(all, m_weights_q);
     save_2d(all, v_weights_q);
 
     save_2d(all, weights_k);
-    save_2d(all, grad_weights_k);
     save_2d(all, m_weights_k);
     save_2d(all, v_weights_k);
 
     save_2d(all, weights_v);
-    save_2d(all, grad_weights_v);
     save_2d(all, m_weights_v);
     save_2d(all, v_weights_v);
 
     save_2d(all, weights_o);
-    save_2d(all, grad_weights_o);
     save_2d(all, m_weights_o);
     save_2d(all, v_weights_o);
 }
 
 void Attention::load_weights(xt::xtensor<float, 1>& all, size_t& index) {
     load_2d(all, weights_q, index);
-    load_2d(all, grad_weights_q, index);
     load_2d(all, m_weights_q, index);
     load_2d(all, v_weights_q, index);
 
     load_2d(all, weights_k, index);
-    load_2d(all, grad_weights_k, index);
     load_2d(all, m_weights_k, index);
     load_2d(all, v_weights_k, index);
 
     load_2d(all, weights_v, index);
-    load_2d(all, grad_weights_v, index);
     load_2d(all, m_weights_v, index);
     load_2d(all, v_weights_v, index);
 
     load_2d(all, weights_o, index);
-    load_2d(all, grad_weights_o, index);
     load_2d(all, m_weights_o, index);
     load_2d(all, v_weights_o, index);
 }

--- a/layers/attention.h
+++ b/layers/attention.h
@@ -59,6 +59,14 @@ public:
 
     void save_weights(std::vector<float>& all) override;
     void load_weights(xt::xtensor<float, 1>& all, size_t& index) override;
+
+    void zero_grad() override {
+        grad_weights_q.fill(0);
+        grad_weights_k.fill(0);
+        grad_weights_v.fill(0);
+        grad_weights_o.fill(0);
+        res_delta = 0;
+    }
 };
 
 

--- a/layers/convolution.cpp
+++ b/layers/convolution.cpp
@@ -162,24 +162,20 @@ void Convolution::update_adamw(float lr, float beta1, float beta2, float weight_
 
 void Convolution::save_weights(std::vector<float>& all) {
     save_4d(all, weights);
-    save_4d(all, grad_weights);
     save_4d(all, m_weights);
     save_4d(all, v_weights);
 
     save_1d(all, biases);
-    save_1d(all, grad_biases);
     save_1d(all, m_biases);
     save_1d(all, v_biases);
 }
 
 void Convolution::load_weights(xt::xtensor<float, 1>& all, size_t& index) {
     load_4d(all, weights, index);
-    load_4d(all, grad_weights, index);
     load_4d(all, m_weights, index);
     load_4d(all, v_weights, index);
 
     load_1d(all, biases, index);
-    load_1d(all, grad_biases, index);
     load_1d(all, m_biases, index);
     load_1d(all, v_biases, index);
 }

--- a/layers/convolution.h
+++ b/layers/convolution.h
@@ -50,6 +50,12 @@ public:
 
     void save_weights(std::vector<float>& all) override;
     void load_weights(xt::xtensor<float, 1>& all, size_t& index) override;
+
+    void zero_grad() override {
+        grad_weights.fill(0);
+        grad_biases.fill(0);
+        res_delta = 0;
+    }
 };
 
 

--- a/layers/dense.cpp
+++ b/layers/dense.cpp
@@ -94,24 +94,20 @@ void Dense::update_adamw(float lr, float beta1, float beta2, float weight_decay,
 
 void Dense::save_weights(std::vector<float>& all) {
     save_2d(all, weights);
-    save_2d(all, grad_weights);
     save_2d(all, m_weights);
     save_2d(all, v_weights);
 
     save_1d(all, biases);
-    save_1d(all, grad_biases);
     save_1d(all, m_biases);
     save_1d(all, v_biases);
 }
 
 void Dense::load_weights(xt::xtensor<float, 1>& all, size_t& index) {
     load_2d(all, weights, index);
-    load_2d(all, grad_weights, index);
     load_2d(all, m_weights, index);
     load_2d(all, v_weights, index);
 
     load_1d(all, biases, index);
-    load_1d(all, grad_biases, index);
     load_1d(all, m_biases, index);
     load_1d(all, v_biases, index);
 }

--- a/layers/dense.h
+++ b/layers/dense.h
@@ -52,6 +52,12 @@ public:
 
     void save_weights(std::vector<float>& all) override;
     void load_weights(xt::xtensor<float, 1>& all, size_t& index) override;
+
+    void zero_grad() override {
+        grad_weights.fill(0);
+        grad_biases.fill(0);
+        res_delta = 0;
+    }
 };
 
 

--- a/layers/embedding.cpp
+++ b/layers/embedding.cpp
@@ -97,24 +97,20 @@ void Embedding::update_adamw(float lr, float beta1, float beta2, float weight_de
 
 void Embedding::save_weights(std::vector<float>& all) {
     save_2d(all, embedding_matrix);
-    save_2d(all, grad_embedding_matrix);
     save_2d(all, m_embedding_matrix);
     save_2d(all, v_embedding_matrix);
 
     save_2d(all, positional_matrix);
-    save_2d(all, grad_positional_matrix);
     save_2d(all, m_positional_matrix);
     save_2d(all, v_positional_matrix);
 }
 
 void Embedding::load_weights(xt::xtensor<float, 1>& all, size_t& index) {
     load_2d(all, embedding_matrix, index);
-    load_2d(all, grad_embedding_matrix, index);
     load_2d(all, m_embedding_matrix, index);
     load_2d(all, v_embedding_matrix, index);
 
     load_2d(all, positional_matrix, index);
-    load_2d(all, grad_positional_matrix, index);
     load_2d(all, m_positional_matrix, index);
     load_2d(all, v_positional_matrix, index);
 }

--- a/layers/embedding.h
+++ b/layers/embedding.h
@@ -46,6 +46,12 @@ public:
 
     void save_weights(std::vector<float>& all) override;
     void load_weights(xt::xtensor<float, 1>& all, size_t& index) override;
+
+    void zero_grad() override {
+        grad_embedding_matrix.fill(0);
+        grad_positional_matrix.fill(0);
+        res_delta = 0;
+    }
 };
 
 #endif //NEURALNETWORK_EMBEDDING_H

--- a/layers/layers.h
+++ b/layers/layers.h
@@ -35,6 +35,11 @@ public:
 
     virtual void save_weights(std::vector<float>& all) = 0;
     virtual void load_weights(xt::xtensor<float, 1>& all, size_t& index) = 0;
+
+    // Clear gradient buffers and residual deltas. Layers that store
+    // trainable parameters should override this if they keep gradient
+    // tensors between updates.
+    virtual void zero_grad() { res_delta = 0; }
 };
 
 

--- a/layers/normalize.cpp
+++ b/layers/normalize.cpp
@@ -91,24 +91,20 @@ void Normalize::update_adamw(float lr, float beta1, float beta2, float weight_de
 
 void Normalize::save_weights(std::vector<float>& all) {
     save_1d(all, gamma);
-    save_1d(all, grad_gamma);
     save_1d(all, m_gamma);
     save_1d(all, v_gamma);
 
     save_1d(all, beta);
-    save_1d(all, grad_beta);
     save_1d(all, m_beta);
     save_1d(all, v_beta);
 }
 
 void Normalize::load_weights(xt::xtensor<float, 1>& all, size_t& index) {
     load_1d(all, gamma, index);
-    load_1d(all, grad_gamma, index);
     load_1d(all, m_gamma, index);
     load_1d(all, v_gamma, index);
 
     load_1d(all, beta, index);
-    load_1d(all, grad_beta, index);
     load_1d(all, m_beta, index);
     load_1d(all, v_beta, index);
 }

--- a/layers/normalize.h
+++ b/layers/normalize.h
@@ -50,6 +50,12 @@ public:
 
     void save_weights(std::vector<float>& all) override;
     void load_weights(xt::xtensor<float, 1>& all, size_t& index) override;
+
+    void zero_grad() override {
+        grad_gamma.fill(0);
+        grad_beta.fill(0);
+        res_delta = 0;
+    }
 };
 
 

--- a/neural_network.cpp
+++ b/neural_network.cpp
@@ -375,6 +375,9 @@ void NeuralNetwork::save(std::string& file_prefix) {
 
     std::ofstream info_file;
     info_file.open(info_file_name);
+    if (!info_file.is_open()) {
+        throw std::runtime_error("Could not open " + info_file_name);
+    }
 
     info_file << train_info.timestep << std::endl;
     info_file << train_info.mini_batch_size << std::endl;
@@ -401,10 +404,17 @@ void NeuralNetwork::load(std::string& file_prefix) {
     size_t index = 0;
     for (std::unique_ptr<Layer>& layer : layers) {
         layer->load_weights(data, index);
+        layer->zero_grad();
+    }
+    if (index != data.size()) {
+        throw std::runtime_error("Weight file size mismatch when loading " + npy_file_name);
     }
 
     std::ifstream info_file;
     info_file.open(info_file_name);
+    if (!info_file.is_open()) {
+        throw std::runtime_error("Could not open " + info_file_name);
+    }
 
     info_file >> train_info.timestep;
     info_file >> train_info.mini_batch_size;


### PR DESCRIPTION
## Summary
- add error checks when saving or loading training metadata
- verify weight file size matches network expectations
- zero all gradient buffers after loading to avoid stale state
- stop persisting gradient tensors in layer weight files

## Testing
- `cmake -B build` *(fails: OpenCV not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d81cfe58832788da0efb881a6e9b